### PR TITLE
feat: allow configuring device logs directory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,7 @@ MAX_SUBSCRIPTIONS_PER_DEVICE=100
 DEBUG_LOGGING=false
 DEBUG_LOGS_DIR=./data/debug-logs
 # STORE_DEVICE_LOGS=true
+# DEVICE_LOGS_DIR=./data/device-logs
 
 # Database configuration
 SQLITE3_DB_PATH=./data/database.sqlite

--- a/README.md
+++ b/README.md
@@ -112,8 +112,12 @@ For **Docker Compose**, edit the `environment:` block in `docker-compose.yml`. F
 | `MAX_SUBSCRIPTIONS_PER_DEVICE` | `100` | Max concurrent subscriptions |
 | `SUSPEND_TIME_MAX` | `600` | Device sleep duration before fallback wake (seconds) |
 | `DEFER_DEVICE_WINDOW` | `15` | Delay before device sends updates after local changes (seconds) |
-| `DEBUG_LOGGING` | `false` | Enable debug logging |
 | `SQLITE3_DB_PATH` | `./data/database.sqlite` | Database file path |
+| `DEBUG_LOGGING` | `false` | Enable detailed request/response logging |
+| `DEBUG_LOGS_DIR` | `./data/device-logs` | Directory for device log files |
+| `STORE_DEVICE_LOGS` | `false` | Store uploaded device logs to disk |
+| `DEVICE_LOGS_DIR` | `./data/device-logs` | Directory for device log files |
+
 
 ### MQTT Configuration (Optional)
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ For **Docker Compose**, edit the `environment:` block in `docker-compose.yml`. F
 | `DEFER_DEVICE_WINDOW` | `15` | Delay before device sends updates after local changes (seconds) |
 | `SQLITE3_DB_PATH` | `./data/database.sqlite` | Database file path |
 | `DEBUG_LOGGING` | `false` | Enable detailed request/response logging |
-| `DEBUG_LOGS_DIR` | `./data/device-logs` | Directory for device log files |
+| `DEBUG_LOGS_DIR` | `./data/debug-logs` | Directory for device log files |
 | `STORE_DEVICE_LOGS` | `false` | Store uploaded device logs to disk |
 | `DEVICE_LOGS_DIR` | `./data/device-logs` | Directory for device log files |
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ For **Docker Compose**, edit the `environment:` block in `docker-compose.yml`. F
 | `DEFER_DEVICE_WINDOW` | `15` | Delay before device sends updates after local changes (seconds) |
 | `SQLITE3_DB_PATH` | `./data/database.sqlite` | Database file path |
 | `DEBUG_LOGGING` | `false` | Enable detailed request/response logging |
-| `DEBUG_LOGS_DIR` | `./data/debug-logs` | Directory for device log files |
+| `DEBUG_LOGS_DIR` | `./data/debug-logs` | Directory for debug log files |
 | `STORE_DEVICE_LOGS` | `false` | Store uploaded device logs to disk |
 | `DEVICE_LOGS_DIR` | `./data/device-logs` | Directory for device log files |
 

--- a/src/nolongerevil/config/environment.py
+++ b/src/nolongerevil/config/environment.py
@@ -108,6 +108,10 @@ class Settings(BaseSettings):
         default=False,
         description="Store uploaded device logs to disk",
     )
+    device_logs_dir: str = Field(
+        default="./data/device-logs",
+        description="Directory for device log files",
+    )
 
     # Database configuration
     sqlite3_db_path: str = Field(

--- a/src/nolongerevil/middleware/debug_logger.py
+++ b/src/nolongerevil/middleware/debug_logger.py
@@ -79,16 +79,15 @@ def create_debug_logger_middleware() -> _MiddlewareType:
         try:
             response = await handler(request)
             elapsed = time.time() - start_time
-            
+
             body_content = None
 
-            if isinstance(response, web.Response):
-                if response.body is not None:
+            if isinstance(response, web.Response) and response.body is not None:
                     try:
                         body_content = response.text if response.text else response.body.decode("utf-8", errors="replace")
                     except Exception:
                         body_content = str(response.body)
-            
+
 
             # Capture response details
             response_data = {

--- a/src/nolongerevil/middleware/debug_logger.py
+++ b/src/nolongerevil/middleware/debug_logger.py
@@ -79,12 +79,23 @@ def create_debug_logger_middleware() -> _MiddlewareType:
         try:
             response = await handler(request)
             elapsed = time.time() - start_time
+            
+            body_content = None
+
+            if isinstance(response, web.Response):
+                if response.body is not None:
+                    try:
+                        body_content = response.text if response.text else response.body.decode("utf-8", errors="replace")
+                    except Exception:
+                        body_content = str(response.body)
+            
 
             # Capture response details
             response_data = {
                 "status": response.status,
                 "headers": dict(response.headers),
                 "elapsed_ms": round(elapsed * 1000, 2),
+                "body": body_content,
             }
 
             # Log to file

--- a/src/nolongerevil/routes/nest/pro_info.py
+++ b/src/nolongerevil/routes/nest/pro_info.py
@@ -6,6 +6,7 @@ from nolongerevil.lib.logger import get_logger
 
 logger = get_logger(__name__)
 
+
 async def handle_pro_info(request: web.Request) -> web.Response:
     """Handle installer information lookup request.
 
@@ -25,19 +26,20 @@ async def handle_pro_info(request: web.Request) -> web.Response:
         {
             "id": 1,
             "pro_id": code,
-            "dba": 'nolongerevil',
-            #"street_address_1": '',
-            #"street_address_2": '',
-            "locality": 'A Self-Hosted Thermostat',
-            #"region": '',
-            #"postal_code": '',
-            #"email": '',
-            #"phone": '',
-            "website": 'https://nolongerevil.com',
+            "dba": "nolongerevil",
+            # "street_address_1": "",
+            # "street_address_2": "",
+            "locality": "A Self-Hosted Thermostat",
+            # "region": "",
+            # "postal_code": "",
+            # "email": "",
+            # "phone": "",
+            "website": "https://nolongerevil.com",
             "rating": 5.0,
-            #"plain_email_address_for_referrals": '',
+            # "plain_email_address_for_referrals": "",
         }
     )
+
 
 def create_pro_info_routes(app: web.Application) -> None:
     """Register pro_info routes.

--- a/src/nolongerevil/routes/nest/pro_info.py
+++ b/src/nolongerevil/routes/nest/pro_info.py
@@ -6,7 +6,6 @@ from nolongerevil.lib.logger import get_logger
 
 logger = get_logger(__name__)
 
-
 async def handle_pro_info(request: web.Request) -> web.Response:
     """Handle installer information lookup request.
 
@@ -20,17 +19,25 @@ async def handle_pro_info(request: web.Request) -> web.Response:
 
     logger.debug(f"Pro info request for code: {code}")
 
-    # Return empty/default pro info
+    # https://github.com/codykociemba/NoLongerEvil-Thermostat/blob/774da29a29bf707c73a5fa666776819d09d09ee7/server/src/routes/nest/proInfo.ts
     return web.json_response(
         {
+            "id": 1,
             "pro_id": code,
-            "company_name": "Self-Hosted",
-            "phone": "",
-            "email": "",
+            "dba": 'nolongerevil',
+            #"street_address_1": '7975 N Hayden Rd',
+            #"street_address_2": 'Suite A210',
+            "locality": 'A Self-Hosted Thermostat',
+            #"region": 'Arizona',
+            #"postal_code": '85388',
+            #"email": 'cody@hackhouse.io',
+            #"phone": '(855) 994-1337',
+            "website": 'https://nolongerevil.com',
+            "rating": 5.0,
+            #"plain_email_address_for_referrals": 'cody@hackhouse.io',
         }
     )
-
-
+    
 def create_pro_info_routes(app: web.Application) -> None:
     """Register pro_info routes.
 

--- a/src/nolongerevil/routes/nest/pro_info.py
+++ b/src/nolongerevil/routes/nest/pro_info.py
@@ -19,25 +19,26 @@ async def handle_pro_info(request: web.Request) -> web.Response:
 
     logger.debug(f"Pro info request for code: {code}")
 
+    # Return empty/default pro info
     # https://github.com/codykociemba/NoLongerEvil-Thermostat/blob/774da29a29bf707c73a5fa666776819d09d09ee7/server/src/routes/nest/proInfo.ts
     return web.json_response(
         {
             "id": 1,
             "pro_id": code,
             "dba": 'nolongerevil',
-            #"street_address_1": '7975 N Hayden Rd',
-            #"street_address_2": 'Suite A210',
+            #"street_address_1": '',
+            #"street_address_2": '',
             "locality": 'A Self-Hosted Thermostat',
-            #"region": 'Arizona',
-            #"postal_code": '85388',
-            #"email": 'cody@hackhouse.io',
-            #"phone": '(855) 994-1337',
+            #"region": '',
+            #"postal_code": '',
+            #"email": '',
+            #"phone": '',
             "website": 'https://nolongerevil.com',
             "rating": 5.0,
-            #"plain_email_address_for_referrals": 'cody@hackhouse.io',
+            #"plain_email_address_for_referrals": '',
         }
     )
-    
+
 def create_pro_info_routes(app: web.Application) -> None:
     """Register pro_info routes.
 

--- a/src/nolongerevil/routes/nest/upload.py
+++ b/src/nolongerevil/routes/nest/upload.py
@@ -12,8 +12,6 @@ from nolongerevil.lib.serial_parser import extract_serial_from_request
 
 logger = get_logger(__name__)
 
-LOG_STORAGE_PATH = Path("/app/data/device_logs")
-
 
 async def handle_upload(request: web.Request) -> web.Response:
     """Handle device log file upload.
@@ -29,7 +27,7 @@ async def handle_upload(request: web.Request) -> web.Response:
         logger.info(f"Received log upload from device {serial or 'unknown'}: {size} bytes")
 
         if settings.store_device_logs:
-            device_dir = LOG_STORAGE_PATH / (serial or "unknown")
+            device_dir = Path(settings.device_logs_dir) / (serial or "unknown")
             device_dir.mkdir(parents=True, exist_ok=True)
 
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")


### PR DESCRIPTION
## Summary

Add support for configuring the device logs directory via `DEVICE_LOGS_DIR`.

## Changes

* Introduced `DEVICE_LOGS_DIR` variable
* Updated log storage to use the configured path
* Updated documentation

## Notes

Keeps previous default behavior when log is not enabled (no breaking changes).
The default folder is now device-logs instead of device_logs to follow the same naming convention as DEBUG_LOGS_DIR

## Testing

* Verify default path is used when not configured
* Verify logs are written to custom path when set
