### PR TITLE
feat: Expose device local_ip and mac_address on Control API responses

### DIFF
--- a/src/nolongerevil/routes/control/status.py
+++ b/src/nolongerevil/routes/control/status.py
@@ -125,6 +125,9 @@ def format_device_status(
         "preconditioning_enabled": device_values.get("preconditioning_enabled"),
         # Backplate (device bucket)
         "backplate_temperature": device_values.get("backplate_temperature"),
+        # Network (device bucket — PUT by the thermostat firmware on every state change)
+        "local_ip": device_values.get("local_ip"),
+        "mac_address": device_values.get("mac_address"),
     }
 
     # Add shared/structure info

--- a/tests/test_device_network_fields.py
+++ b/tests/test_device_network_fields.py
@@ -1,0 +1,134 @@
+"""Tests for local_ip and mac_address exposure in /api/devices and /status responses.
+
+These fields live in the device.{serial} bucket (PUT by firmware on every state change)
+but were not surfaced in the Control API responses. format_device_status() now extracts
+them; both routes go through it, so both endpoints are asserted here to prevent a
+future refactor from dropping one.
+"""
+
+import json
+import time
+from datetime import datetime
+from unittest.mock import Mock
+
+import pytest
+from aiohttp import web
+
+from nolongerevil.lib.types import DeviceObject
+from nolongerevil.routes.control.status import handle_devices, handle_status
+from nolongerevil.services.device_availability import DeviceAvailability
+from nolongerevil.services.device_state_service import DeviceStateService
+from nolongerevil.services.subscription_manager import SubscriptionManager
+
+SERIAL = "02AA01AB501203EQ"
+LOCAL_IP = "192.168.1.42"
+# Bare-hex (no separators), matching the firmware's wire format —
+# verified against a live Gen 1 device on 2026-05-20.
+MAC_ADDRESS = "18b430000000"
+
+
+def _make_status_request(
+    state_service: DeviceStateService,
+    device_availability: DeviceAvailability,
+    serial: str = SERIAL,
+) -> Mock:
+    req = Mock(spec=web.Request)
+    req.query = {"serial": serial}
+    req.app = {
+        "state_service": state_service,
+        "device_availability": device_availability,
+    }
+    return req
+
+
+def _make_devices_request(
+    state_service: DeviceStateService,
+    device_availability: DeviceAvailability,
+    subscription_manager: SubscriptionManager,
+) -> Mock:
+    req = Mock(spec=web.Request)
+    # 'storage' key omitted so handle_devices falls back to
+    # state_service.get_all_serials() instead of requiring a pairing storage layer.
+    req.app = {
+        "state_service": state_service,
+        "device_availability": device_availability,
+        "subscription_manager": subscription_manager,
+    }
+    return req
+
+
+async def _seed_device(
+    state_service: DeviceStateService,
+    *,
+    serial: str = SERIAL,
+    extra_values: dict | None = None,
+) -> None:
+    values: dict = {"current_temperature": 21.0, "target_temperature": 22.0}
+    if extra_values:
+        values.update(extra_values)
+    await state_service.upsert_object(
+        DeviceObject(
+            serial=serial,
+            object_key=f"device.{serial}",
+            object_revision=1,
+            object_timestamp=int(time.time() * 1000),
+            value=values,
+            updated_at=datetime.now(),
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_status_surfaces_local_ip_and_mac_when_present(
+    state_service: DeviceStateService,
+    device_availability: DeviceAvailability,
+) -> None:
+    await _seed_device(
+        state_service,
+        extra_values={"local_ip": LOCAL_IP, "mac_address": MAC_ADDRESS},
+    )
+
+    resp = await handle_status(_make_status_request(state_service, device_availability))
+    body = json.loads(resp.body)
+
+    assert body["local_ip"] == LOCAL_IP
+    assert body["mac_address"] == MAC_ADDRESS
+
+
+@pytest.mark.asyncio
+async def test_status_local_ip_and_mac_null_when_absent(
+    state_service: DeviceStateService,
+    device_availability: DeviceAvailability,
+) -> None:
+    await _seed_device(state_service)
+
+    resp = await handle_status(_make_status_request(state_service, device_availability))
+    body = json.loads(resp.body)
+
+    assert "local_ip" in body
+    assert body["local_ip"] is None
+    assert "mac_address" in body
+    assert body["mac_address"] is None
+
+
+@pytest.mark.asyncio
+async def test_devices_endpoint_surfaces_local_ip_and_mac(
+    state_service: DeviceStateService,
+    device_availability: DeviceAvailability,
+    subscription_manager: SubscriptionManager,
+) -> None:
+    await _seed_device(
+        state_service,
+        extra_values={"local_ip": LOCAL_IP, "mac_address": MAC_ADDRESS},
+    )
+
+    resp = await handle_devices(
+        _make_devices_request(state_service, device_availability, subscription_manager)
+    )
+    body = json.loads(resp.body)
+
+    assert body["total"] == 1
+    device = body["devices"][0]
+    assert device["serial"] == SERIAL
+    assert device["local_ip"] == LOCAL_IP
+    assert device["mac_address"] == MAC_ADDRESS


### PR DESCRIPTION
Closes #23.

## What

Two-line addition to `format_device_status()` in `src/nolongerevil/routes/control/status.py` to surface `local_ip` and `mac_address` (already stored in the `device.{serial}` bucket by the firmware) on `GET /api/devices` and `GET /status?serial=X`.

```diff
         # Backplate (device bucket)
         "backplate_temperature": device_values.get("backplate_temperature"),
+        # Network (device bucket — PUT by the thermostat firmware on every state change)
+        "local_ip": device_values.get("local_ip"),
+        "mac_address": device_values.get("mac_address"),
     }
```

Both endpoints route through `format_device_status()`, so this single edit covers both.

## Tests

New `tests/test_device_network_fields.py` with three cases:

1. `test_status_surfaces_local_ip_and_mac_when_present` — populated fields come through on `/status?serial=X`.
2. `test_status_local_ip_and_mac_null_when_absent` — missing fields surface as `null` (matching the `structure_id` / `schedule_mode` pattern).
3. `test_devices_endpoint_surfaces_local_ip_and_mac` — same data exposed on `/api/devices`. Locks in that both call sites stay routed through `format_device_status()` so a future refactor can't drop one.

Test patterns mirror `tests/test_transport_put.py` (`Mock(spec=web.Request)` + direct handler invocation, `state_service.upsert_object(DeviceObject(...))` for bucket seeding).

## Real-device verification

Verified against a running Gen 2 thermostat on firmware ~5.9.x (2026-05-20) via direct SQLite inspection of the live server's `states` table. Two devices on the same server, abbreviated output:

```
02AA01ACxxxxxxJM  local_ip="192.168.1.82"   mac_address="18b430xxxxxx"
02AA01ACxxxxxxZK  local_ip="192.168.1.26"   mac_address="18b430xxxxxx"
```

Both keys are stored under exactly the names assumed in this change. The MAC is **bare-hex (12 chars, no separators)** — passed through unchanged; downstream clients can format for display if they wish. The issue body (#23) has been updated to reflect the verified shapes.

## Backward compatibility

Strictly additive — no existing field renamed, removed, or restructured. Clients that don't know about the new keys will continue to work; clients that do will see `null` until the device has PUT at least once (same handling as existing nullable fields like `structure_id`).

## Pre-push gate (locally green)

All five CI checks pass against `mypy 1.20.2`, which matches the last green CI run on `main` (April 1, 2026):

- `ruff check src/` ✓
- `ruff format --check src/` ✓
- `mypy src/nolongerevil --ignore-missing-imports` ✓
- `pytest tests/ -v --cov=nolongerevil` ✓ (217 passed, +3 new)
- `bandit -r src/nolongerevil -lll` ✓

## Note: pre-existing mypy 2.x incompatibility on `main`

Heads-up unrelated to this change: with `mypy 2.x` (which `pip install .[dev]` now pulls because `pyproject.toml` specifies `mypy>=1.7.0`), unmodified `main` reports 3 pre-existing errors (2 unused `type: ignore` in `services/subscription_manager.py`, 1 `int | float → int` assignment in `integrations/mqtt/mqtt_integration.py`). Nothing in this PR introduces new mypy errors — those 3 surface against `main` itself. If CI here turns red on type-check, that's the cause, and it would be the maintainer's call whether to pin `mypy<2.0`, fix the three sites, or upgrade past them. Happy to send a separate small PR for whichever path is preferred.
