### PR TITLE
fix: Pin Hatchling version to fix error when installing dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.14"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dev = [
     "pytest-cov>=4.1.0",
     "pytest-aiohttp>=1.0.5",
     "ruff>=0.1.0",
-    "mypy>=1.7.0",
+    "mypy~=1.20.2",
     "pre-commit>=3.6.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling ~= 1.29.0"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
This PR fixes #28.

The main fix is pinning Hatchling to version 1.29. The newest version of Hatchling (1.30) throws an error when processing the current `pyproject.toml`. Specifically, it has some issue with the `tool.hatch.build.targets.wheel.force-include` section. Additionally, I edited the test job in `ci.yml` to use Python 3.12 like the other CI jobs and the Docker image. Lastly, I pinned Mypy to version 1.20, since the newest version (2.1) brings up issues in code which I didn't change.