### PR TITLE
fix(fan): preserve active hold across stale device echo + atomic MQTT bucket writes

### DIFF
--- a/src/nolongerevil/integrations/mqtt/mqtt_integration.py
+++ b/src/nolongerevil/integrations/mqtt/mqtt_integration.py
@@ -11,7 +11,8 @@ Outbound (device → MQTT):
   exposes)
 
 Inbound (MQTT → device):
-- Subscribes to two command topic patterns:
+- Subscribes to three command topic patterns:
+    {prefix}/+/+/set       — atomic raw bucket writes (e.g., .../device/set)
     {prefix}/+/+/+/set     — raw field writes (e.g., .../shared/target_temperature/set)
     {prefix}/+/ha/+/set    — HA-native commands (e.g., .../ha/mode/set)
 - Dispatches commands via execute_command() from command.py, which merges
@@ -187,7 +188,9 @@ class MqttIntegration(BaseIntegration):
 
         # Raw command topics
         if self._publish_raw:
+            await client.subscribe(f"{prefix}/+/+/set")
             await client.subscribe(f"{prefix}/+/+/+/set")
+            logger.debug(f"Subscribed to {prefix}/+/+/set")
             logger.debug(f"Subscribed to {prefix}/+/+/+/set")
 
         # HA command topics
@@ -354,26 +357,41 @@ class MqttIntegration(BaseIntegration):
             await self._publish_ha_state(self._active_client, serial)
 
     async def _handle_raw_command(self, topic: str, payload: str) -> None:
-        """Handle raw MQTT command."""
+        """Handle an atomic bucket or legacy single-field raw MQTT command."""
         prefix = self._topic_prefix
         escaped_prefix = re.escape(prefix)
-        match = re.match(rf"^{escaped_prefix}/([^/]+)/([^/]+)/([^/]+)/set$", topic)
-        if not match:
+        field_match = re.match(rf"^{escaped_prefix}/([^/]+)/([^/]+)/([^/]+)/set$", topic)
+        bucket_match = re.match(rf"^{escaped_prefix}/([^/]+)/([^/]+)/set$", topic)
+        if not field_match and not bucket_match:
             return
 
-        serial, object_type, field = match.groups()
+        if field_match:
+            serial, object_type, field = field_match.groups()
+            value: Any = payload
+            try:
+                value = json.loads(payload)
+            except json.JSONDecodeError:
+                with contextlib.suppress(ValueError):
+                    value = float(payload)
+            values = {field: value}
+            command_description = f"{object_type}.{field} = {value}"
+        else:
+            assert bucket_match is not None
+            serial, object_type = bucket_match.groups()
+            try:
+                parsed_payload = json.loads(payload)
+            except json.JSONDecodeError:
+                logger.warning(f"Invalid raw bucket JSON for {serial}/{object_type}")
+                return
+            if not isinstance(parsed_payload, dict) or not parsed_payload:
+                logger.warning(
+                    f"Raw bucket command for {serial}/{object_type} must be a non-empty object"
+                )
+                return
+            values = parsed_payload
+            command_description = f"{object_type} = {values}"
 
-        # Parse value
-        value: Any = payload
-        try:
-            value = json.loads(payload)
-        except json.JSONDecodeError:
-            import contextlib
-
-            with contextlib.suppress(ValueError):
-                value = float(payload)
-
-        logger.info(f"Raw Command: {serial}/{object_type}.{field} = {value}")
+        logger.info(f"Raw Command: {serial}/{command_description}")
 
         from datetime import datetime
 
@@ -386,7 +404,7 @@ class MqttIntegration(BaseIntegration):
             logger.warning(f"Object not found: {object_key}")
             return
 
-        new_value = {**current_obj.value, field: value}
+        new_value = {**current_obj.value, **values}
         new_revision = current_obj.object_revision + 1
         new_timestamp = int(time.time() * 1000)
 
@@ -399,7 +417,7 @@ class MqttIntegration(BaseIntegration):
             updated_at=datetime.now(),
         )
         await self._state_service.upsert_object(obj)
-        logger.info(f"Applied raw command to {serial}: {{{field}: {value}}}")
+        logger.info(f"Applied raw command to {serial}: {values}")
 
         # Push to subscribed device immediately
         if self._subscription_manager:

--- a/src/nolongerevil/utils/fan_timer.py
+++ b/src/nolongerevil/utils/fan_timer.py
@@ -22,23 +22,6 @@ def get_fan_timer_state(values: dict[str, Any]) -> FanTimerState:
     return FanTimerState(timeout=int(timeout) if timeout is not None else None)
 
 
-def is_explicitly_turning_off_fan(new_values: dict[str, Any]) -> bool:
-    """Check if values explicitly turn off the fan.
-
-    Args:
-        new_values: Incoming device values
-
-    Returns:
-        True if explicitly disabling fan
-    """
-    # Check fan_timer_timeout = 0
-    if "fan_timer_timeout" in new_values and new_values["fan_timer_timeout"] == 0:
-        return True
-
-    # Check fan_control_state = false
-    return "fan_control_state" in new_values and new_values["fan_control_state"] is False
-
-
 def is_fan_timer_active(state: FanTimerState) -> bool:
     """Check if a fan timer is currently active.
 
@@ -106,11 +89,6 @@ def preserve_fan_timer_state(
 
     result = new_values.copy()
 
-    # Check if explicitly turning off fan
-    if is_explicitly_turning_off_fan(new_values):
-        logger.debug("Fan timer explicitly disabled" + (f" for device {serial}" if serial else ""))
-        return result
-
     # Get current fan timer state
     current_state = get_fan_timer_state(existing_values)
 
@@ -118,12 +96,23 @@ def preserve_fan_timer_state(
         # No active timer, nothing to preserve
         return result
 
-    # Preserve all fan-related fields from existing values
-    # Only if not explicitly being set in new values
+    # This function is called only while merging thermostat-originated state.
+    # A device may echo its stale pre-command fan fields before it applies the
+    # server push. Preserve the authoritative active hold when that echo says
+    # timeout=0/control=false. Explicit API/MQTT fan-off commands update server
+    # state through execute_command() and do not pass here. A positive timeout
+    # from the device is real progress and remains authoritative.
     fan_fields = extract_fan_timer_fields(existing_values)
     for key, value in fan_fields.items():
         if key not in new_values:
             result[key] = value
+
+    incoming_timeout = new_values.get("fan_timer_timeout")
+    if not isinstance(incoming_timeout, (int, float)) or incoming_timeout <= int(time.time()):
+        result["fan_timer_timeout"] = current_state.timeout
+
+    if existing_values.get("fan_control_state") is True:
+        result["fan_control_state"] = True
 
     logger.debug(
         f"Preserving active fan timer (timeout={current_state.timeout})"

--- a/src/nolongerevil/utils/fan_timer.py
+++ b/src/nolongerevil/utils/fan_timer.py
@@ -108,9 +108,12 @@ def preserve_fan_timer_state(
             result[key] = value
 
     incoming_timeout = new_values.get("fan_timer_timeout")
-    try:
-        normalized_timeout = int(incoming_timeout)
-    except (TypeError, ValueError, OverflowError):
+    if isinstance(incoming_timeout, (int, float, str)):
+        try:
+            normalized_timeout = int(incoming_timeout)
+        except (ValueError, OverflowError):
+            normalized_timeout = 0
+    else:
         normalized_timeout = 0
     if normalized_timeout <= int(time.time()):
         result["fan_timer_timeout"] = current_state.timeout

--- a/src/nolongerevil/utils/fan_timer.py
+++ b/src/nolongerevil/utils/fan_timer.py
@@ -108,7 +108,11 @@ def preserve_fan_timer_state(
             result[key] = value
 
     incoming_timeout = new_values.get("fan_timer_timeout")
-    if not isinstance(incoming_timeout, (int, float)) or incoming_timeout <= int(time.time()):
+    try:
+        normalized_timeout = int(incoming_timeout)
+    except (TypeError, ValueError, OverflowError):
+        normalized_timeout = 0
+    if normalized_timeout <= int(time.time()):
         result["fan_timer_timeout"] = current_state.timeout
 
     if existing_values.get("fan_control_state") is True:

--- a/tests/test_fan_timer.py
+++ b/tests/test_fan_timer.py
@@ -73,15 +73,16 @@ class TestPreserveFanTimerState:
 
         assert result["fan_timer_timeout"] == future_timeout
 
-    def test_explicit_fan_off_overrides(self):
-        """Test that explicit fan-off command overrides preservation."""
+    def test_device_fan_off_echo_does_not_override_active_server_timer(self):
+        """A thermostat echo cannot cancel an active server-side timer."""
         future_timeout = int(time.time()) + 3600
-        existing = {"fan_timer_timeout": future_timeout}
-        new_values = {"fan_timer_timeout": 0}
+        existing = {"fan_timer_timeout": future_timeout, "fan_control_state": True}
+        new_values = {"fan_timer_timeout": 0, "fan_control_state": False}
 
         result = preserve_fan_timer_state(existing, new_values)
 
-        assert result["fan_timer_timeout"] == 0
+        assert result["fan_timer_timeout"] == future_timeout
+        assert result["fan_control_state"] is True
 
     def test_explicit_new_timeout(self):
         """Test that new timeout value is used."""

--- a/tests/test_fan_timer.py
+++ b/tests/test_fan_timer.py
@@ -93,3 +93,12 @@ class TestPreserveFanTimerState:
         result = preserve_fan_timer_state(existing, new_values)
 
         assert result["fan_timer_timeout"] == new_timeout
+
+    def test_explicit_new_timeout_as_numeric_string(self):
+        """Test that a new numeric-string timeout is used."""
+        existing = {"fan_timer_timeout": int(time.time()) + 3600}
+        new_timeout = str(int(time.time()) + 7200)
+
+        result = preserve_fan_timer_state(existing, {"fan_timer_timeout": new_timeout})
+
+        assert result["fan_timer_timeout"] == new_timeout

--- a/tests/test_mqtt_commands.py
+++ b/tests/test_mqtt_commands.py
@@ -1,0 +1,60 @@
+"""Regression tests for MQTT commands pushed to Nest devices."""
+
+import json
+from datetime import datetime
+
+import pytest
+
+from nolongerevil.integrations.mqtt.mqtt_integration import MqttIntegration
+from nolongerevil.lib.types import DeviceObject, IntegrationConfig
+from nolongerevil.services.device_state_service import DeviceStateService
+from nolongerevil.services.subscription_manager import SubscriptionManager
+
+SERIAL = "TEST12345678"
+
+
+def mqtt_integration(
+    state_service: DeviceStateService,
+    subscription_manager: SubscriptionManager,
+) -> MqttIntegration:
+    now = datetime.now()
+    config = IntegrationConfig(
+        user_id="test",
+        type="mqtt",
+        enabled=True,
+        config={"topicPrefix": "nolongerevil", "publishRaw": True},
+        created_at=now,
+        updated_at=now,
+    )
+    return MqttIntegration(config, state_service, subscription_manager)
+
+
+@pytest.mark.asyncio
+async def test_raw_bucket_command_pushes_related_fields_atomically(
+    state_service: DeviceStateService,
+    subscription_manager: SubscriptionManager,
+) -> None:
+    await state_service.upsert_object(
+        DeviceObject(
+            serial=SERIAL,
+            object_key=f"device.{SERIAL}",
+            object_revision=10,
+            object_timestamp=1000,
+            value={"fan_control_state": False, "fan_timer_timeout": 0},
+            updated_at=datetime.now(),
+        )
+    )
+    subscription = await subscription_manager.add_long_poll_subscription(SERIAL, "session")
+    assert subscription is not None
+
+    integration = mqtt_integration(state_service, subscription_manager)
+    await integration._handle_raw_command(
+        f"nolongerevil/{SERIAL}/device/set",
+        json.dumps({"fan_control_state": True, "fan_timer_timeout": 2_000_000_000}),
+    )
+
+    pushed = subscription.notify_queue.get_nowait()
+    assert len(pushed) == 1
+    assert pushed[0]["value"]["fan_control_state"] is True
+    assert pushed[0]["value"]["fan_timer_timeout"] == 2_000_000_000
+    assert subscription.notify_queue.empty()


### PR DESCRIPTION
Fixes #35.

## Why

An active server-issued fan timer can be erased by the thermostat's first stale state echo. The server pushes a future `fan_timer_timeout` with `fan_control_state=true`; before applying it, the device may report its previous `timeout=0/control=false` values. The transport merge currently treats that report as an explicit cancellation, so fan-only operation never begins.

Closing that race also surfaced a second one on the MQTT command side: a caller that wants to set `fan_control_state` and `fan_timer_timeout` together previously had to publish them as two separate field-level MQTT messages, which reopens the exact same kind of race between the two writes. This PR adds support for a single atomic raw-bucket MQTT topic (`{prefix}/+/+/set`) so related fields land in one state update.

Size: M

## Acceptance criteria

- Preserve an active server fan timeout when a thermostat-originated update echoes an expired or zero timeout.
- Preserve `fan_control_state=true` across the same stale device echo.
- Continue accepting positive device timer updates and all updates after the server timer expires.
- Keep explicit API and MQTT fan cancellation on their existing command path.
- Support an atomic raw-bucket MQTT command topic (`{prefix}/+/+/set`) that applies multiple related fields (e.g. `fan_control_state` + `fan_timer_timeout`) in one state update, alongside the existing per-field topic.

## Test plan

- `uv run --extra dev pytest -q` (all tests pass, including the new `tests/test_mqtt_commands.py`)
- `uv run --extra dev ruff check src/nolongerevil/utils/fan_timer.py src/nolongerevil/integrations/mqtt/mqtt_integration.py tests/test_fan_timer.py tests/test_mqtt_commands.py`
- `uv run --extra dev ruff format --check` (same file set)
- Verified live in production against a real Nest thermostat: two independent natural cool-to-off transitions (2026-07-18 00:26:54-00:27:09 UTC and 00:47:33-00:47:49 UTC), each showing the fan hold surviving the device's stale echo instead of being cancelled - see the PR comment with exact timestamps/telemetry.

## Out of scope

- Thermostat scheduling policy and fan-hold duration.
- Home Assistant action-state presentation while HVAC mode is off.
